### PR TITLE
feat: add a check on the owner of the repo

### DIFF
--- a/.github/workflows/checkmarx-analysis.yml
+++ b/.github/workflows/checkmarx-analysis.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   code-analysis:
     name: Run Checkmarx
-    runs-on: ${{ github.repository_visibility != 'public' && 'centreon-security' || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.repository_visibility != 'public' && github.repository_owner == 'centreon') && 'centreon-security' || 'ubuntu-24.04' }}
 
     steps:
       - name: Check parameters

--- a/.github/workflows/dependency-analysis.yml
+++ b/.github/workflows/dependency-analysis.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   dependency-scan:
     name: Run dependencies analysis
-    runs-on: ${{ github.repository_visibility != 'public' && 'centreon-security' || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.repository_visibility != 'public' && github.repository_owner == 'centreon') && 'centreon-security' || 'ubuntu-24.04' }}
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/gitleaks-analysis.yml
+++ b/.github/workflows/gitleaks-analysis.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   secret-scan:
     name: Run Gitleaks
-    runs-on: ${{ github.repository_visibility != 'public' && 'centreon-security' || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.repository_visibility != 'public' && github.repository_owner == 'centreon') && 'centreon-security' || 'ubuntu-24.04' }}
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Add a check on the owner of the repo for the reusable workflows.

Previously, if you have a private repository in another organization, it would call the centreon-security runners.
Those runners are only registered under the centreon organization. Meaning it would try to spin up the centreon-security runners in an organization that doesn't have access to them.

This PR adds a check on the repo owner. If the repo owner is not the centreon organization it uses the ubuntu-24.04 runners.

This is useful for this repo in the centreon-website organization :
https://github.com/centreon-website/website
Currently since this repo is private it tries to uses the centreon-security runners but can't and gets stuck waiting.
With this PR it should use the public ubuntu-24.04 runners.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added repository owner check to choose appropriate GitHub runner


<sup>[More info](https://app.aikido.dev/featurebranch/scan/91104548?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->